### PR TITLE
Install git on the target system

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,8 @@
 ---
+- name: Ensure dependencies are installed
+  package:
+    name: git
+
 - name: Load ansible-module-openshift
   include_role:
     name: ansible-role-openshift-zabbix-monitoring/vendor/ansible-module-openshift


### PR DESCRIPTION
When instantiating the template, `oc` expects `git` to be installed. If this is not the case, Ansible displays a very cryptic error message which does not include `oc`'s original error message (that it is missing `git`).