### PR TITLE
Replace `ansible_ssh_*` vars with `ansible_*`

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -8,7 +8,7 @@
     loop_var: host
   when: "{{ hostvars[host]['openshift_node_labels']['host-monitoring'] is defined }}"
   delegate_to: "{{ host }}"
-  remote_user: "{{ ansible_ssh_user | default(omit) }}"  # Work around Ansible issue regarding copy, delegate_to and sudo
+  remote_user: "{{ ansible_user | default(omit) }}"  # Work around Ansible issue regarding copy, delegate_to and sudo
   become: "{{ ansible_become | default(omit) }}"
 
 #  when: osohm_service_enabled | bool

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -231,7 +231,7 @@
     loop_var: host
   when: "{{ hostvars[host]['openshift_node_labels']['host-monitoring'] is defined }}"
   delegate_to: "{{ host }}"
-  remote_user: "{{ ansible_ssh_user | default(omit) }}"  # Work around Ansible issue regarding copy, delegate_to and sudo
+  remote_user: "{{ ansible_user | default(omit) }}"  # Work around Ansible issue regarding copy, delegate_to and sudo
   become: "{{ ansible_become | default(omit) }}"
 
 - name: Configure additional cluster stats


### PR DESCRIPTION
The ansible_ssh_user, ansible_ssh_host, and ansible_ssh_port vars were deprecated in Ansible 2.0.